### PR TITLE
feat(metrics): add traditional methods for comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test/
 data/
 checkpoints/
 cache_dir
+experiments/
 
 ##### Python.gitignore #####
 # Byte-compiled / optimized / DLL files

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,15 +48,31 @@ Then, you can run the following script to train the reward model on the SafeSora
 
 ```bash
 bash examples/scripts/finetune_reward_model.sh \
+    --video_dir <your-video-dir> \
+    --train_data_path <your-train-data-path> \
+    --eval_data_path <your-eval-data-path> \
     --model_name_or_path <your-model-name-or-checkpoint-path> \
     --mm_mlp_adapter_path <your-mm_mlp_adapter_path> \
-    --dimension <the-target-dimension-to-train> \
-    --output_dir examples/outputs/reward-model
+    --output_dir <output-directory> \
+    --dimension <the-target-dimension-to-train>
 ```
 
-where `<your-model-name-or-checkpoint-path>` is the name of the Video-LLaVA model or the path to the checkpoint directory, `<your-mm_mlp_adapter_path>` is the path to the `mm_projector.bin` file, and `<the-target-dimension-to-train>` is the preference dimension that the reward model will predict.
+where `<your-video-dir>` is the path to the directory containing the video files, `<your-train-data-path>` and `<your-eval-data-path>` are the paths to the training and evaluation data files, `<your-model-name-or-checkpoint-path>` is the name of the Video-LLaVA model or the path to the checkpoint directory, `<your-mm_mlp_adapter_path>` is the path to the `mm_projector.bin` file, and `<the-target-dimension-to-train>` is the preference dimension that the reward model will predict.
 
 **NOTE:** The parameter 'dimension' specifies the preference dimension that the reward model will predict. The SafeSora dataset currently supports the following dimensions: `helpfulness`, `harmlessness`, `instruction_following`, `correctness`, `informativeness`, and `aesthetics`. For the detailed information of the different dimensions, please refer to our [paper](https://arxiv.org/abs/2406.14477).
+
+For example, preference dataset is placed in `data/SafeSora`, the Video-LLaVA model is downloaded to `models/LanguageBind/Video-LLaVA-7B`, and the MM-MLP adapter is downloaded to `models/LanguageBind/Video-LLaVA-Pretrain-7B`, you can run the following command to train the reward model on the `helpfulness` dimension:
+
+```bash
+bash examples/scripts/finetune_reward_model.sh \
+    --video_dir data/SafeSora/videos \
+    --train_data_path data/SafeSora/config-train.json.gz \
+    --eval_data_path data/SafeSora/config-test.json.gz \
+    --model_name_or_path models/LanguageBind/Video-LLaVA-7B \
+    --mm_mlp_adapter_path models/LanguageBind/Video-LLaVA-Pretrain-7B/mm_projector.bin \
+    --output_dir ./outputs \
+    --dimension helpfulness
+```
 
 ## Acknowledgements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dependencies = [
     "tqdm",
     "rich",
     "av",
+    "opencv-python",
+    "scikit-image",
 ]
 dynamic = ["version"]
 

--- a/safe_sora/datasets/base.py
+++ b/safe_sora/datasets/base.py
@@ -199,7 +199,7 @@ class SubPreference(TypedDict, total=False):
 
     instruction_following: NotRequired[Literal['video_0', 'video_1']]
     correctness: NotRequired[Literal['video_0', 'video_1']]
-    informativeness: NotRequired[Literal['video_0', 'video_1']]
+    information: NotRequired[Literal['video_0', 'video_1']]
     aesthetics: NotRequired[Literal['video_0', 'video_1']]
 
 
@@ -214,7 +214,7 @@ def format_sub_preference_from_dict(data: dict) -> SubPreference:
     return SubPreference(
         instruction_following=data.get('instruction_following'),
         correctness=data.get('correctness'),
-        informativeness=data.get('informativeness'),
+        information=data.get('information'),
         aesthetics=data.get('aesthetics'),
     )
 

--- a/safe_sora/datasets/base.py
+++ b/safe_sora/datasets/base.py
@@ -430,7 +430,7 @@ class BaseDataset(Dataset):
         """Check if the dataset is complete, i.e., all values are not None."""
         return all(is_complete(config) for config in self.configs)
 
-    def check_video_integrity(self) -> None:
+    def check_video_integrity(self) -> int:
         """Check if videos are corrupted"""
 
         has_checked_path = set()
@@ -456,6 +456,8 @@ class BaseDataset(Dataset):
             tqdm_bar.set_description(f'Number of corrupted videos: {num_corrupted_videos}')
             tqdm_bar.update(1)
         tqdm_bar.close()
+
+        return num_corrupted_videos
 
     def shuffle(self) -> None:
         """Shuffle the dataset"""

--- a/safe_sora/metrics.py
+++ b/safe_sora/metrics.py
@@ -1,0 +1,78 @@
+"""Traditional metrics for video generation."""
+
+import os
+
+import clip
+import cv2
+import hpsv2
+import numpy as np
+import torch
+from PIL import Image
+from skimage.metrics import peak_signal_noise_ratio as psnr  # pylint: disable=no-name-in-module
+
+
+def extract_frames(video_path: str) -> tuple:
+    """Extract frames from video file."""
+    video_capture = cv2.VideoCapture(video_path)  # pylint: disable=no-member
+    if not video_capture.isOpened():
+        print(f'Error opening video file: {video_path}')
+        return None
+    all_frames = []
+    frame_count = 0
+    while True:
+        ret, frame = video_capture.read()
+        if not ret:
+            break
+        all_frames.append(frame)
+        frame_count += 1
+
+    video_capture.release()
+    return all_frames, frame_count
+
+
+def get_psnr(video_path: str) -> float:
+    """Calculate the average PSNR of a video."""
+    frames, frame_num = extract_frames(video_path)
+    image_0 = cv2.cvtColor(frames[0], cv2.COLOR_BGR2RGB)  # pylint: disable=no-member
+    psnr_sum = 0
+    for i in range(1, frame_num):
+        image = cv2.cvtColor(frames[i], cv2.COLOR_BGR2RGB)  # pylint: disable=no-member
+        psnr_sum += psnr(image_0, image)
+    return psnr_sum / frame_num
+
+
+def hpsv2_reward(prompt: str, video_path: str, cache_dir: str, sample_rate: int = 1) -> float:
+    """Calculate the average HPSv2 score of a video."""
+    reward = []
+    temp_save_path = os.path.join(cache_dir, 'temp.png')
+    frames, frame_num = extract_frames(video_path)
+    index = np.linspace(0, frame_num - 1, frame_num, dtype=int)
+    frames = [frames[i] for i in index[:: int(1 / sample_rate)]]
+    for _, frame in enumerate(frames):
+        image = Image.fromarray(frame)
+        image.save(temp_save_path)
+        reward.append(hpsv2.score(temp_save_path, prompt, hps_version='v2.1'))
+        os.remove(temp_save_path)
+    mean_reward = np.mean(reward)
+    return mean_reward.item()
+
+
+class ClipReward:  # pylint: disable=too-few-public-methods
+    """Calculate the average CLIP score of a video."""
+
+    def __init__(self, device: str) -> None:
+        self.device = device
+        self.model, self.preprocess = clip.load('ViT-B/32', device=self.device)
+        print('device:', self.device)
+
+    def __call__(self, prompt: str, video_path: str) -> float:
+        frames, _ = extract_frames(video_path)
+        text = clip.tokenize(prompt, truncate=True).to(self.device)
+        reward = []
+        for i in len(frames):
+            image = Image.fromarray(frames[i])
+            image = self.preprocess(image).unsqueeze(0).to(self.device)
+            with torch.no_grad():
+                logits_per_image, _ = self.model(image, text)
+            reward.append(logits_per_image[0][0].item())
+        return np.mean(reward)

--- a/safe_sora/metrics.py
+++ b/safe_sora/metrics.py
@@ -1,14 +1,29 @@
+# Copyright 2024 PKU-Alignment Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """Traditional metrics for video generation."""
 
 import os
 
-import clip
+import clip  # pylint: disable=import-error
 import cv2
-import hpsv2
+import hpsv2  # pylint: disable=import-error
 import numpy as np
 import torch
 from PIL import Image
-from skimage.metrics import peak_signal_noise_ratio as psnr  # pylint: disable=no-name-in-module
+from skimage.metrics.simple_metrics import peak_signal_noise_ratio as psnr
 
 
 def extract_frames(video_path: str) -> tuple:
@@ -30,7 +45,7 @@ def extract_frames(video_path: str) -> tuple:
     return all_frames, frame_count
 
 
-def get_psnr(video_path: str) -> float:
+def psnr_reward(video_path: str) -> float:
     """Calculate the average PSNR of a video."""
     frames, frame_num = extract_frames(video_path)
     image_0 = cv2.cvtColor(frames[0], cv2.COLOR_BGR2RGB)  # pylint: disable=no-member

--- a/safe_sora/utils.py
+++ b/safe_sora/utils.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Utility functions for SafeSora."""
 
+from __future__ import annotations
+
 import hashlib
 import json
 

--- a/safe_sora/utils.py
+++ b/safe_sora/utils.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Utility functions for SafeSora."""
 
+import hashlib
+import json
+
 import numpy as np
 import torch
 import torch.distributed as dist
@@ -39,3 +42,13 @@ def order_pick_k(lst: list, k: int) -> list:
     new_lst = [lst[i] for i in index_sort]
     print(f'WARNING: total file: {len(lst)}, random pick: {k}. (ignored)')
     return new_lst
+
+
+def generate_hash_uid(to_hash: dict | tuple | list | str) -> str:
+    """Generates a unique hash for a given model and arguments."""
+    # Convert the dictionary to a JSON string
+    json_string = json.dumps(to_hash, sort_keys=True)
+
+    # Generate a hash of the JSON string
+    hash_object = hashlib.sha256(json_string.encode())
+    return hash_object.hexdigest()


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

While some traditional methods may not precisely capture human value preferences, they are usually faster and cheaper to compute. Therefore, we will integrate some traditional metrics into the SafeSora library, expecting they will complement feedback-based methods and enable comparative analysis.

These methods include:

- **PSNR vs. Informativeness:** PSNR measures the quality of a reconstructed or compressed image/video by comparing it to the original, and assessing their similarity. We evaluate dynamic changes in the video by analyzing PSNR between the first and subsequent frames.
- **HPSv2 vs. Aesthetic:** HPSv2 predicts human preferences for image beauty. We use it to assess the aesthetics of each video frame, averaging the results for an overall aesthetic measure.
- **CLIP vs. Instruction Following:** CLIP assesses instruction adherence by evaluating the similarity between the prompt and video frames.

More methods will be added gradually in the future.

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/safe-sora/issues) for new features and bug fixes) 

See #4 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
